### PR TITLE
Add option to publish stub files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ return [
 ];
 ```
 
+You can publish the stub files with:
+
+```bash
+php artisan vendor:publish --tag="rbac-stubs"
+```
+
 ## Usage
 
 ```bash

--- a/src/Commands/AbilityMakeCommand.php
+++ b/src/Commands/AbilityMakeCommand.php
@@ -26,7 +26,9 @@ class AbilityMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../../stubs/ability.stub';
+        return file_exists($customPath = base_path('/stubs/ability.stub'))
+            ? $customPath
+            : __DIR__.'/../../stubs/ability.stub';
     }
 
     /**

--- a/src/Commands/DefinedRoleMakeCommand.php
+++ b/src/Commands/DefinedRoleMakeCommand.php
@@ -25,7 +25,9 @@ class DefinedRoleMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../../stubs/defined-role.stub';
+        return file_exists($customPath = base_path('/stubs/defined-role.stub'))
+            ? $customPath
+            : __DIR__.'/../../stubs/defined-role.stub';
     }
 
     /**

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -28,7 +28,7 @@ class RbacServiceProvider extends PackageServiceProvider
         parent::packageBooted();
 
         $this->publishes([
-            __DIR__.'/../stubs/ability.stub' => base_path('stubs/ability.stub'),
+            __DIR__.'/../stubs/ability.stub'      => base_path('stubs/ability.stub'),
             __DIR__.'/../stubs/defined-role.stub' => base_path('stubs/defined-role.stub'),
         ], ['rbac-stubs', 'stubs']);
     }

--- a/src/RbacServiceProvider.php
+++ b/src/RbacServiceProvider.php
@@ -23,6 +23,16 @@ class RbacServiceProvider extends PackageServiceProvider
             ]);
     }
 
+    public function packageBooted()
+    {
+        parent::packageBooted();
+
+        $this->publishes([
+            __DIR__.'/../stubs/ability.stub' => base_path('stubs/ability.stub'),
+            __DIR__.'/../stubs/defined-role.stub' => base_path('stubs/defined-role.stub'),
+        ], ['rbac-stubs', 'stubs']);
+    }
+
     /**
      * @return void
      */


### PR DESCRIPTION
This will make it possible to publish the stub files and utilize them when they are published. This feature was mentioned in the README but wasn't existing yet. 

@cyrillkalita if this is something you'd consider merging, I'd happily add some tests, but I prefer to get your opinion first. The code is functional as is, the only thing that is needed are some tests to make sure it keeps working 😁
